### PR TITLE
Add PostgreSQL support with Docker and backup routines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# PostgreSQL Configuration
+POSTGRES_USER=passwault
+POSTGRES_PASSWORD=your_secure_password_here
+POSTGRES_DB=passwault
+POSTGRES_PORT=5432
+
+# Backup Configuration
+BACKUP_SCHEDULE=0 2 * * *
+BACKUP_RETENTION_DAYS=30
+HOST_BACKUP_DIR=~/.passwault/backups
+
+# Application Database URL (for passwault CLI)
+# Uncomment to use PostgreSQL instead of SQLite
+# DATABASE_URL=postgresql://passwault:your_secure_password_here@localhost:5432/passwault

--- a/.gitignore
+++ b/.gitignore
@@ -221,4 +221,8 @@ __marimo__/
 *.txt
 settings.json
 
+.claude
+CLAUDE.md
+
+
 files/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,51 @@ Passwault is a command-line password manager that prioritizes security and priva
    uv run passwault get -n github
    ```
 
+## 🗄️ Database Configuration
+
+By default, Passwault uses SQLite and stores data in `~/.passwault/`. For advanced users, PostgreSQL is also supported.
+
+### Configuration Priority
+
+Passwault loads database configuration in this order:
+
+1. **Environment variable** (highest priority): `DATABASE_URL`
+2. **Config file**: `~/.config/passwault/.env`
+3. **Default**: SQLite at `~/.passwault/passwault.db`
+
+### Using PostgreSQL
+
+#### Option 1: Environment Variable
+
+```bash
+export DATABASE_URL="postgresql://user:password@localhost:5432/passwault"
+passwault auth login -u yourname
+```
+
+#### Option 2: Config File
+
+Create a config file at `~/.config/passwault/.env`:
+
+```bash
+mkdir -p ~/.config/passwault
+echo 'DATABASE_URL="postgresql://user:password@localhost:5432/passwault"' > ~/.config/passwault/.env
+```
+
+This is the recommended approach when installing passwault as a uv tool:
+
+```bash
+uv tool install passwault
+passwault auth login -u yourname  # Uses config from ~/.config/passwault/.env
+```
+
+### Default SQLite (No Configuration Needed)
+
+If no `DATABASE_URL` is set, Passwault automatically uses SQLite:
+
+```bash
+passwault auth register -u yourname  # Data stored in ~/.passwault/passwault.db
+```
+
 ## 📚 Complete Command Reference
 
 ### Authentication Commands

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+
+services:
+  # PostgreSQL Database
+  postgres:
+    image: postgres:16-alpine
+    container_name: passwault-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-passwault}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-passwault}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-passwault} -d ${POSTGRES_DB:-passwault}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - passwault-network
+
+  # Backup Service (runs pg_dump on schedule)
+  backup:
+    image: postgres:16-alpine
+    container_name: passwault-backup
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGHOST: postgres
+      PGUSER: ${POSTGRES_USER:-passwault}
+      PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      PGDATABASE: ${POSTGRES_DB:-passwault}
+      BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-0 2 * * *}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-30}
+    volumes:
+      - ./docker/backup/scripts:/scripts:ro
+      - backup_data:/backups
+      - ${HOST_BACKUP_DIR:-~/.passwault/backups}:/host-backups
+    entrypoint: ["/scripts/entrypoint.sh"]
+    networks:
+      - passwault-network
+
+volumes:
+  postgres_data:
+    driver: local
+  backup_data:
+    driver: local
+
+networks:
+  passwault-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       retries: 5
     networks:
       - passwault-network
+    env_file:
+      - .env
 
   # Backup Service (runs pg_dump on schedule)
   backup:

--- a/docker/backup/scripts/backup.sh
+++ b/docker/backup/scripts/backup.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="/backups/passwault_${TIMESTAMP}.sql.gz"
+HOST_BACKUP_FILE="/host-backups/passwault_${TIMESTAMP}.sql.gz"
+
+echo "$(date): Starting backup..."
+
+# Create backup with pg_dump
+pg_dump -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" \
+    --format=plain \
+    --no-owner \
+    --no-privileges \
+    | gzip > "$BACKUP_FILE"
+
+# Copy to host-mounted directory
+if [ -d "/host-backups" ]; then
+    cp "$BACKUP_FILE" "$HOST_BACKUP_FILE"
+    echo "$(date): Backup copied to host: $HOST_BACKUP_FILE"
+fi
+
+echo "$(date): Backup created: $BACKUP_FILE"
+
+# Cleanup old backups (both in container and host)
+echo "$(date): Cleaning up backups older than ${BACKUP_RETENTION_DAYS} days..."
+
+find /backups -name "passwault_*.sql.gz" -type f -mtime +${BACKUP_RETENTION_DAYS} -delete 2>/dev/null || true
+find /host-backups -name "passwault_*.sql.gz" -type f -mtime +${BACKUP_RETENTION_DAYS} -delete 2>/dev/null || true
+
+# List current backups
+echo "$(date): Current backups:"
+ls -lah /backups/*.sql.gz 2>/dev/null || echo "No backups found in container"
+
+echo "$(date): Backup completed successfully"

--- a/docker/backup/scripts/entrypoint.sh
+++ b/docker/backup/scripts/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+echo "Starting backup scheduler..."
+echo "Schedule: $BACKUP_SCHEDULE"
+echo "Retention: $BACKUP_RETENTION_DAYS days"
+
+# Install required packages
+apk add --no-cache dcron
+
+# Create cron job
+echo "$BACKUP_SCHEDULE /scripts/backup.sh >> /var/log/backup.log 2>&1" > /etc/crontabs/root
+
+# Ensure log file exists
+touch /var/log/backup.log
+
+# Run initial backup
+echo "Running initial backup..."
+/scripts/backup.sh
+
+# Start cron daemon in foreground
+echo "Starting cron daemon..."
+crond -f -l 2

--- a/docker/postgres/init/01-init.sql
+++ b/docker/postgres/init/01-init.sql
@@ -1,0 +1,8 @@
+-- PostgreSQL initialization script for Passwault
+-- This runs automatically on first container start
+
+-- Enable useful extensions
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Grant all privileges to the application user
+GRANT ALL PRIVILEGES ON DATABASE passwault TO passwault;

--- a/passwault/__main__.py
+++ b/passwault/__main__.py
@@ -4,10 +4,36 @@ This module initializes the database and launches the CLI interface.
 Handles automatic migration from old plain-text schema to encrypted schema.
 """
 
+import os
+from pathlib import Path
+
 from dotenv import load_dotenv
 
-# Load .env BEFORE importing models (which creates the database engine at import time)
-load_dotenv()
+
+def load_database_config():
+    """Load database configuration with fallback chain.
+
+    Priority order:
+    1. DATABASE_URL environment variable (highest priority)
+    2. ~/.config/passwault/.env config file
+    3. Default SQLite (handled by models.py)
+    """
+    # If DATABASE_URL is already set, use it (highest priority)
+    if os.environ.get("DATABASE_URL"):
+        return
+
+    # Try loading from user config directory
+    config_env_path = Path.home() / ".config" / "passwault" / ".env"
+    if config_env_path.exists():
+        load_dotenv(config_env_path)
+        return
+
+    # Fall back to local .env file (for development)
+    load_dotenv()
+
+
+# Load database config BEFORE importing models (which creates the database engine at import time)
+load_database_config()
 
 from passwault.core.cli import cli  # noqa: E402
 from passwault.core.database.models import Base, engine  # noqa: E402

--- a/passwault/__main__.py
+++ b/passwault/__main__.py
@@ -4,9 +4,14 @@ This module initializes the database and launches the CLI interface.
 Handles automatic migration from old plain-text schema to encrypted schema.
 """
 
-from passwault.core.cli import cli
-from passwault.core.database.models import Base, engine
-from passwault.core.utils.session_manager import SessionManager
+from dotenv import load_dotenv
+
+# Load .env BEFORE importing models (which creates the database engine at import time)
+load_dotenv()
+
+from passwault.core.cli import cli  # noqa: E402
+from passwault.core.database.models import Base, engine  # noqa: E402
+from passwault.core.utils.session_manager import SessionManager  # noqa: E402
 
 
 def main():

--- a/passwault/core/config.py
+++ b/passwault/core/config.py
@@ -1,0 +1,87 @@
+"""Application configuration management.
+
+Handles database URL parsing and environment-based configuration.
+"""
+
+import os
+from enum import Enum
+from pathlib import Path
+
+from passwault.core.utils.data_dir import get_data_dir
+
+
+class DatabaseType(Enum):
+    """Supported database backends."""
+
+    SQLITE = "sqlite"
+    POSTGRESQL = "postgresql"
+
+
+class Config:
+    """Application configuration from environment variables."""
+
+    # Environment variable names
+    ENV_DATABASE_URL = "DATABASE_URL"
+    ENV_BACKUP_DIR = "PASSWAULT_BACKUP_DIR"
+
+    @classmethod
+    def get_database_url(cls) -> str:
+        """Get database URL from environment or default to SQLite.
+
+        Returns:
+            Database URL string (SQLite path or PostgreSQL connection string)
+        """
+        database_url = os.environ.get(cls.ENV_DATABASE_URL)
+
+        if database_url:
+            return database_url
+
+        # Default to SQLite
+        db_path = get_data_dir() / "passwault.db"
+        return f"sqlite:///{db_path}"
+
+    @classmethod
+    def get_database_type(cls) -> DatabaseType:
+        """Determine database type from URL.
+
+        Returns:
+            DatabaseType enum value
+
+        Raises:
+            ValueError: If database URL scheme is not supported
+        """
+        url = cls.get_database_url()
+
+        if url.startswith("sqlite"):
+            return DatabaseType.SQLITE
+        elif url.startswith("postgresql") or url.startswith("postgres"):
+            return DatabaseType.POSTGRESQL
+        else:
+            raise ValueError(f"Unsupported database URL scheme: {url}")
+
+    @classmethod
+    def get_backup_dir(cls) -> Path:
+        """Get backup directory from environment or default.
+
+        Returns:
+            Path to backup directory
+        """
+        backup_dir = os.environ.get(cls.ENV_BACKUP_DIR)
+
+        if backup_dir:
+            path = Path(backup_dir)
+        else:
+            path = Path.home() / ".passwault" / "backups"
+
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    @classmethod
+    def is_postgresql(cls) -> bool:
+        """Check if using PostgreSQL backend."""
+        return cls.get_database_type() == DatabaseType.POSTGRESQL
+
+    @classmethod
+    def is_sqlite(cls) -> bool:
+        """Check if using SQLite backend."""
+        return cls.get_database_type() == DatabaseType.SQLITE

--- a/passwault/core/services/backup_service.py
+++ b/passwault/core/services/backup_service.py
@@ -1,0 +1,282 @@
+"""Backup service for database backup and restore operations.
+
+Supports both SQLite (file copy) and PostgreSQL (pg_dump) backups.
+"""
+
+import gzip
+import os
+import shutil
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import urlparse
+
+from passwault.core.config import Config, DatabaseType
+
+
+class BackupService:
+    """Service for database backup operations."""
+
+    def __init__(self, backup_dir: Optional[Path] = None):
+        """Initialize backup service.
+
+        Args:
+            backup_dir: Custom backup directory (uses config default if None)
+        """
+        self.backup_dir = backup_dir or Config.get_backup_dir()
+        self.database_type = Config.get_database_type()
+        self.database_url = Config.get_database_url()
+
+    def create_backup(self, compress: bool = True) -> Path:
+        """Create a database backup.
+
+        Args:
+            compress: Whether to gzip the backup (default: True)
+
+        Returns:
+            Path to the created backup file
+
+        Raises:
+            RuntimeError: If backup fails
+        """
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        if self.database_type == DatabaseType.SQLITE:
+            return self._backup_sqlite(timestamp, compress)
+        else:
+            return self._backup_postgresql(timestamp, compress)
+
+    def _backup_sqlite(self, timestamp: str, compress: bool) -> Path:
+        """Create SQLite backup by copying the database file.
+
+        Args:
+            timestamp: Backup timestamp string
+            compress: Whether to compress the backup
+
+        Returns:
+            Path to backup file
+        """
+        # Extract path from sqlite:///path URL
+        db_path = Path(self.database_url.replace("sqlite:///", ""))
+
+        if not db_path.exists():
+            raise RuntimeError(f"Database file not found: {db_path}")
+
+        if compress:
+            backup_file = self.backup_dir / f"passwault_{timestamp}.db.gz"
+            with open(db_path, "rb") as f_in:
+                with gzip.open(backup_file, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+        else:
+            backup_file = self.backup_dir / f"passwault_{timestamp}.db"
+            shutil.copy2(db_path, backup_file)
+
+        return backup_file
+
+    def _backup_postgresql(self, timestamp: str, compress: bool) -> Path:
+        """Create PostgreSQL backup using pg_dump.
+
+        Args:
+            timestamp: Backup timestamp string
+            compress: Whether to compress the backup
+
+        Returns:
+            Path to backup file
+
+        Raises:
+            RuntimeError: If pg_dump fails or is not available
+        """
+        # Check if pg_dump is available
+        if shutil.which("pg_dump") is None:
+            raise RuntimeError(
+                "pg_dump not found. Install PostgreSQL client tools to use backup feature."
+            )
+
+        # Parse PostgreSQL connection URL
+        parsed = urlparse(self.database_url)
+
+        env = {
+            **os.environ,
+            "PGPASSWORD": parsed.password or "",
+        }
+
+        cmd = [
+            "pg_dump",
+            "-h",
+            parsed.hostname or "localhost",
+            "-p",
+            str(parsed.port or 5432),
+            "-U",
+            parsed.username or "passwault",
+            "-d",
+            parsed.path.lstrip("/"),
+            "--format=plain",
+            "--no-owner",
+            "--no-privileges",
+        ]
+
+        if compress:
+            backup_file = self.backup_dir / f"passwault_{timestamp}.sql.gz"
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                env=env,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"pg_dump failed: {result.stderr.decode()}")
+
+            with gzip.open(backup_file, "wb") as f:
+                f.write(result.stdout)
+        else:
+            backup_file = self.backup_dir / f"passwault_{timestamp}.sql"
+            with open(backup_file, "wb") as f:
+                result = subprocess.run(
+                    cmd,
+                    stdout=f,
+                    stderr=subprocess.PIPE,
+                    env=env,
+                )
+
+            if result.returncode != 0:
+                backup_file.unlink(missing_ok=True)
+                raise RuntimeError(f"pg_dump failed: {result.stderr.decode()}")
+
+        return backup_file
+
+    def list_backups(self) -> List[Path]:
+        """List all available backups.
+
+        Returns:
+            List of backup file paths, sorted by modification time (newest first)
+        """
+        patterns = [
+            "passwault_*.db",
+            "passwault_*.db.gz",
+            "passwault_*.sql",
+            "passwault_*.sql.gz",
+        ]
+
+        backups = []
+        for pattern in patterns:
+            backups.extend(self.backup_dir.glob(pattern))
+
+        return sorted(backups, key=lambda p: p.stat().st_mtime, reverse=True)
+
+    def restore_backup(self, backup_path: Path) -> None:
+        """Restore database from a backup file.
+
+        Args:
+            backup_path: Path to the backup file
+
+        Raises:
+            RuntimeError: If restore fails
+            ValueError: If backup file type doesn't match database type
+        """
+        if not backup_path.exists():
+            raise RuntimeError(f"Backup file not found: {backup_path}")
+
+        # Determine backup type from filename
+        name = backup_path.name
+        if ".db.gz" in name or name.endswith(".db"):
+            backup_type = DatabaseType.SQLITE
+        elif ".sql.gz" in name or name.endswith(".sql"):
+            backup_type = DatabaseType.POSTGRESQL
+        else:
+            raise ValueError(f"Unknown backup file type: {backup_path}")
+
+        if backup_type != self.database_type:
+            raise ValueError(
+                f"Backup type ({backup_type.value}) doesn't match "
+                f"current database ({self.database_type.value})"
+            )
+
+        if backup_type == DatabaseType.SQLITE:
+            self._restore_sqlite(backup_path)
+        else:
+            self._restore_postgresql(backup_path)
+
+    def _restore_sqlite(self, backup_path: Path) -> None:
+        """Restore SQLite database from backup."""
+        db_path = Path(self.database_url.replace("sqlite:///", ""))
+
+        # Create backup of current database
+        if db_path.exists():
+            current_backup = db_path.with_suffix(".db.bak")
+            shutil.copy2(db_path, current_backup)
+
+        # Restore
+        if backup_path.suffix == ".gz":
+            with gzip.open(backup_path, "rb") as f_in:
+                with open(db_path, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+        else:
+            shutil.copy2(backup_path, db_path)
+
+    def _restore_postgresql(self, backup_path: Path) -> None:
+        """Restore PostgreSQL database from backup."""
+        # Check if psql is available
+        if shutil.which("psql") is None:
+            raise RuntimeError(
+                "psql not found. Install PostgreSQL client tools to use restore feature."
+            )
+
+        parsed = urlparse(self.database_url)
+
+        env = {
+            **os.environ,
+            "PGPASSWORD": parsed.password or "",
+        }
+
+        cmd = [
+            "psql",
+            "-h",
+            parsed.hostname or "localhost",
+            "-p",
+            str(parsed.port or 5432),
+            "-U",
+            parsed.username or "passwault",
+            "-d",
+            parsed.path.lstrip("/"),
+        ]
+
+        if backup_path.suffix == ".gz":
+            with gzip.open(backup_path, "rt") as f:
+                result = subprocess.run(
+                    cmd,
+                    stdin=f,
+                    capture_output=True,
+                    env=env,
+                    text=True,
+                )
+        else:
+            with open(backup_path, "r") as f:
+                result = subprocess.run(
+                    cmd,
+                    stdin=f,
+                    capture_output=True,
+                    env=env,
+                    text=True,
+                )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"psql restore failed: {result.stderr}")
+
+    def cleanup_old_backups(self, retention_days: int = 30) -> int:
+        """Remove backups older than retention period.
+
+        Args:
+            retention_days: Number of days to retain backups
+
+        Returns:
+            Number of backups removed
+        """
+        cutoff = datetime.now() - timedelta(days=retention_days)
+        removed = 0
+
+        for backup in self.list_backups():
+            if datetime.fromtimestamp(backup.stat().st_mtime) < cutoff:
+                backup.unlink()
+                removed += 1
+
+        return removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ dependencies = [
     "sqlalchemy>=2.0.44",
 ]
 
+[project.optional-dependencies]
+postgres = [
+    "psycopg2-binary>=2.9.9",
+]
+
 [project.scripts]
 passwault = "passwault.__main__:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,11 @@ dependencies = [
     "cryptography>=45.0.6",
     "numpy>=2.3.2",
     "pillow>=11.3.0",
+    "psycopg2-binary>=2.9.11",
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
     "pytest-mock>=3.14.1",
+    "python-dotenv>=1.2.1",
     "sqlalchemy>=2.0.44",
 ]
 

--- a/scripts/migrate_to_postgres.py
+++ b/scripts/migrate_to_postgres.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Migration script from SQLite to PostgreSQL.
+
+This script migrates all users and their encrypted passwords from a SQLite
+database to a PostgreSQL database. The encrypted data is copied as-is,
+preserving the encryption.
+
+Usage:
+    python scripts/migrate_to_postgres.py \\
+        --sqlite-path ~/.local/share/passwault/passwault.db \\
+        --postgres-url postgresql://user:pass@localhost:5432/passwault
+
+Options:
+    --dry-run    Show what would be migrated without making changes
+    --verbose    Show detailed progress information
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add project root to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import create_engine, text  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from passwault.core.database.models import Base, User, PasswordManager  # noqa: E402
+
+
+def check_sqlite_exists(sqlite_path: str) -> bool:
+    """Check if SQLite database file exists."""
+    path = Path(sqlite_path)
+    if not path.exists():
+        print(f"Error: SQLite database not found: {sqlite_path}")
+        return False
+    return True
+
+
+def check_postgres_connection(postgres_url: str) -> bool:
+    """Check if PostgreSQL connection works."""
+    try:
+        engine = create_engine(postgres_url)
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        engine.dispose()
+        return True
+    except Exception as e:
+        print(f"Error: Cannot connect to PostgreSQL: {e}")
+        return False
+
+
+def get_table_counts(session) -> dict:
+    """Get counts of records in each table."""
+    user_count = session.query(User).count()
+    password_count = session.query(PasswordManager).count()
+    return {"users": user_count, "passwords": password_count}
+
+
+def migrate(
+    sqlite_path: str,
+    postgres_url: str,
+    dry_run: bool = False,
+    verbose: bool = False,
+):
+    """Migrate data from SQLite to PostgreSQL.
+
+    Args:
+        sqlite_path: Path to SQLite database file
+        postgres_url: PostgreSQL connection URL
+        dry_run: If True, show what would be migrated without executing
+        verbose: If True, show detailed progress
+    """
+    # Connect to SQLite
+    sqlite_engine = create_engine(f"sqlite:///{sqlite_path}")
+    SqliteSession = sessionmaker(bind=sqlite_engine)
+    sqlite_session = SqliteSession()
+
+    # Connect to PostgreSQL
+    postgres_engine = create_engine(postgres_url)
+
+    if not dry_run:
+        # Create tables in PostgreSQL
+        print("Creating tables in PostgreSQL...")
+        Base.metadata.create_all(postgres_engine)
+
+    PostgresSession = sessionmaker(bind=postgres_engine)
+    postgres_session = PostgresSession()
+
+    try:
+        # Get source counts
+        source_counts = get_table_counts(sqlite_session)
+        print("\nSource database (SQLite):")
+        print(f"  Users: {source_counts['users']}")
+        print(f"  Passwords: {source_counts['passwords']}")
+
+        if source_counts["users"] == 0:
+            print("\nNo data to migrate.")
+            return
+
+        # Check if destination already has data
+        if not dry_run:
+            dest_counts = get_table_counts(postgres_session)
+            if dest_counts["users"] > 0:
+                print("\nWarning: PostgreSQL database already has data:")
+                print(f"  Users: {dest_counts['users']}")
+                print(f"  Passwords: {dest_counts['passwords']}")
+                response = input("Continue and add to existing data? [y/N]: ")
+                if response.lower() != "y":
+                    print("Migration cancelled.")
+                    return
+
+        # Migrate users
+        users = sqlite_session.query(User).all()
+        print(f"\nMigrating {len(users)} user(s)...")
+
+        user_id_map = {}  # Map old user IDs to new user IDs
+
+        for user in users:
+            if verbose:
+                print(f"  Processing user: {user.username}")
+
+            if dry_run:
+                print(f"  [DRY RUN] Would migrate user: {user.username}")
+                user_id_map[user.id] = user.id  # Keep same ID for dry run
+                continue
+
+            # Create new user in PostgreSQL
+            new_user = User(
+                username=user.username,
+                email=user.email,
+                master_password_hash=user.master_password_hash,
+                salt=user.salt,
+                kdf_algorithm=user.kdf_algorithm,
+                kdf_iterations=user.kdf_iterations,
+                created_at=user.created_at,
+                updated_at=user.updated_at,
+                last_login=user.last_login,
+            )
+            postgres_session.add(new_user)
+            postgres_session.flush()  # Get the new ID
+
+            user_id_map[user.id] = new_user.id
+
+            if verbose:
+                print(f"    Migrated user ID {user.id} -> {new_user.id}")
+
+        # Migrate passwords
+        passwords = sqlite_session.query(PasswordManager).all()
+        print(f"\nMigrating {len(passwords)} password(s)...")
+
+        migrated_passwords = 0
+        for pwd in passwords:
+            if verbose:
+                print(f"  Processing password: {pwd.resource_name} (user_id={pwd.user_id})")
+
+            if pwd.user_id not in user_id_map:
+                print(f"  Warning: Skipping orphaned password {pwd.resource_name} (user_id={pwd.user_id})")
+                continue
+
+            if dry_run:
+                print(f"  [DRY RUN] Would migrate password: {pwd.resource_name}")
+                migrated_passwords += 1
+                continue
+
+            new_pwd = PasswordManager(
+                user_id=user_id_map[pwd.user_id],
+                resource_name=pwd.resource_name,
+                username=pwd.username,
+                encrypted_password=pwd.encrypted_password,
+                nonce=pwd.nonce,
+                website=pwd.website,
+                description=pwd.description,
+                tags=pwd.tags,
+                created_at=pwd.created_at,
+                updated_at=pwd.updated_at,
+            )
+            postgres_session.add(new_pwd)
+            migrated_passwords += 1
+
+            if verbose:
+                print(f"    Migrated password for user_id {pwd.user_id} -> {user_id_map[pwd.user_id]}")
+
+        if not dry_run:
+            postgres_session.commit()
+            print("\nMigration completed successfully!")
+            print(f"  Users migrated: {len(users)}")
+            print(f"  Passwords migrated: {migrated_passwords}")
+
+            # Verify migration
+            dest_counts = get_table_counts(postgres_session)
+            print("\nDestination database (PostgreSQL):")
+            print(f"  Users: {dest_counts['users']}")
+            print(f"  Passwords: {dest_counts['passwords']}")
+        else:
+            print("\n[DRY RUN] Migration preview completed.")
+            print(f"  Users would be migrated: {len(users)}")
+            print(f"  Passwords would be migrated: {migrated_passwords}")
+
+    except Exception as e:
+        postgres_session.rollback()
+        print(f"\nMigration failed: {e}")
+        raise
+
+    finally:
+        sqlite_session.close()
+        postgres_session.close()
+        sqlite_engine.dispose()
+        postgres_engine.dispose()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate Passwault database from SQLite to PostgreSQL",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Preview migration (no changes made)
+  python scripts/migrate_to_postgres.py \\
+      --sqlite-path ~/.local/share/passwault/passwault.db \\
+      --postgres-url postgresql://passwault:pass@localhost:5432/passwault \\
+      --dry-run
+
+  # Run migration with verbose output
+  python scripts/migrate_to_postgres.py \\
+      --sqlite-path ~/.local/share/passwault/passwault.db \\
+      --postgres-url postgresql://passwault:pass@localhost:5432/passwault \\
+      --verbose
+        """,
+    )
+    parser.add_argument(
+        "--sqlite-path",
+        required=True,
+        help="Path to SQLite database file",
+    )
+    parser.add_argument(
+        "--postgres-url",
+        required=True,
+        help="PostgreSQL connection URL (e.g., postgresql://user:pass@host:5432/db)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be migrated without making changes",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show detailed progress information",
+    )
+
+    args = parser.parse_args()
+
+    # Validate inputs
+    if not check_sqlite_exists(args.sqlite_path):
+        sys.exit(1)
+
+    if not args.dry_run and not check_postgres_connection(args.postgres_url):
+        sys.exit(1)
+
+    # Run migration
+    migrate(
+        sqlite_path=args.sqlite_path,
+        postgres_url=args.postgres_url,
+        dry_run=args.dry_run,
+        verbose=args.verbose,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backup_service.py
+++ b/tests/test_backup_service.py
@@ -1,0 +1,310 @@
+"""Tests for backup service."""
+
+import os
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from passwault.core.config import Config, DatabaseType
+from passwault.core.services.backup_service import BackupService
+
+
+@pytest.fixture
+def temp_backup_dir():
+    """Create temporary backup directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def mock_sqlite_db(temp_backup_dir):
+    """Create a mock SQLite database file."""
+    db_path = temp_backup_dir / "test.db"
+    # Create a minimal SQLite database
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("INSERT INTO test (name) VALUES ('test_data')")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def mock_sqlite_config(monkeypatch, mock_sqlite_db, temp_backup_dir):
+    """Mock configuration for SQLite testing."""
+    backup_dir = temp_backup_dir / "backups"
+    backup_dir.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(
+        Config, "get_database_url", lambda: f"sqlite:///{mock_sqlite_db}"
+    )
+    monkeypatch.setattr(Config, "get_database_type", lambda: DatabaseType.SQLITE)
+    monkeypatch.setattr(Config, "get_backup_dir", lambda: backup_dir)
+
+    return mock_sqlite_db, backup_dir
+
+
+class TestBackupServiceInit:
+    """Test BackupService initialization."""
+
+    def test_init_with_default_backup_dir(self, mock_sqlite_config):
+        """Test initialization with default backup directory."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService()
+
+        assert service.backup_dir == backup_dir
+        assert service.database_type == DatabaseType.SQLITE
+
+    def test_init_with_custom_backup_dir(self, mock_sqlite_config, temp_backup_dir):
+        """Test initialization with custom backup directory."""
+        custom_dir = temp_backup_dir / "custom_backups"
+        custom_dir.mkdir(exist_ok=True)
+
+        service = BackupService(backup_dir=custom_dir)
+
+        assert service.backup_dir == custom_dir
+
+
+class TestSQLiteBackup:
+    """Test SQLite backup operations."""
+
+    def test_create_backup_compressed(self, mock_sqlite_config, temp_backup_dir):
+        """Test creating compressed SQLite backup."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        backup_path = service.create_backup(compress=True)
+
+        assert backup_path.exists()
+        assert backup_path.suffix == ".gz"
+        assert "passwault_" in backup_path.name
+        assert backup_path.stat().st_size > 0
+
+    def test_create_backup_uncompressed(self, mock_sqlite_config, temp_backup_dir):
+        """Test creating uncompressed SQLite backup."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        backup_path = service.create_backup(compress=False)
+
+        assert backup_path.exists()
+        assert backup_path.suffix == ".db"
+        assert "passwault_" in backup_path.name
+
+    def test_create_backup_missing_database(self, monkeypatch, temp_backup_dir):
+        """Test backup fails when database file doesn't exist."""
+        nonexistent_db = temp_backup_dir / "nonexistent.db"
+        backup_dir = temp_backup_dir / "backups"
+        backup_dir.mkdir(exist_ok=True)
+
+        monkeypatch.setattr(
+            Config, "get_database_url", lambda: f"sqlite:///{nonexistent_db}"
+        )
+        monkeypatch.setattr(Config, "get_database_type", lambda: DatabaseType.SQLITE)
+        monkeypatch.setattr(Config, "get_backup_dir", lambda: backup_dir)
+
+        service = BackupService()
+
+        with pytest.raises(RuntimeError, match="Database file not found"):
+            service.create_backup()
+
+
+class TestListBackups:
+    """Test backup listing."""
+
+    def test_list_backups_empty(self, mock_sqlite_config):
+        """Test listing when no backups exist."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        backups = service.list_backups()
+
+        assert len(backups) == 0
+
+    def test_list_backups_multiple(self, mock_sqlite_config):
+        """Test listing multiple backups."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        # Create multiple backups with different names manually
+        backup1 = service.create_backup()
+        time.sleep(1.1)  # Ensure different timestamps (need > 1 second)
+        backup2 = service.create_backup()
+
+        backups = service.list_backups()
+
+        assert len(backups) == 2
+        # Newest first
+        assert backups[0] == backup2
+        assert backups[1] == backup1
+
+    def test_list_backups_filters_by_pattern(self, mock_sqlite_config, temp_backup_dir):
+        """Test that only passwault backup files are listed."""
+        _, backup_dir = mock_sqlite_config
+
+        # Create a non-backup file
+        other_file = backup_dir / "other_file.txt"
+        other_file.write_text("not a backup")
+
+        service = BackupService(backup_dir=backup_dir)
+        service.create_backup()
+
+        backups = service.list_backups()
+
+        assert len(backups) == 1
+        assert "passwault_" in backups[0].name
+
+
+class TestRestoreBackup:
+    """Test backup restoration."""
+
+    def test_restore_sqlite_backup_uncompressed(self, mock_sqlite_config):
+        """Test restoring uncompressed SQLite backup."""
+        db_path, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        # Create backup
+        backup_path = service.create_backup(compress=False)
+
+        # Modify original database
+        import sqlite3
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DELETE FROM test")
+        conn.commit()
+        conn.close()
+
+        # Restore
+        service.restore_backup(backup_path)
+
+        # Verify data is restored
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.execute("SELECT name FROM test")
+        rows = cursor.fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "test_data"
+
+    def test_restore_sqlite_backup_compressed(self, mock_sqlite_config):
+        """Test restoring compressed SQLite backup."""
+        db_path, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        # Create backup
+        backup_path = service.create_backup(compress=True)
+
+        # Modify original database
+        import sqlite3
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DELETE FROM test")
+        conn.commit()
+        conn.close()
+
+        # Restore
+        service.restore_backup(backup_path)
+
+        # Verify data is restored
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.execute("SELECT name FROM test")
+        rows = cursor.fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+
+    def test_restore_creates_backup_of_current(self, mock_sqlite_config):
+        """Test that restore creates backup of current database."""
+        db_path, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        # Create and restore backup
+        backup_path = service.create_backup(compress=False)
+        service.restore_backup(backup_path)
+
+        # Check that .bak file was created
+        bak_file = db_path.with_suffix(".db.bak")
+        assert bak_file.exists()
+
+    def test_restore_nonexistent_backup(self, mock_sqlite_config, temp_backup_dir):
+        """Test restore fails for nonexistent backup file."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        nonexistent = temp_backup_dir / "nonexistent.db"
+
+        with pytest.raises(RuntimeError, match="Backup file not found"):
+            service.restore_backup(nonexistent)
+
+    def test_restore_wrong_database_type(self, mock_sqlite_config, temp_backup_dir):
+        """Test restore fails when backup type doesn't match database type."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        # Create a fake PostgreSQL backup file
+        fake_pg_backup = backup_dir / "passwault_test.sql"
+        fake_pg_backup.write_text("-- fake postgres backup")
+
+        with pytest.raises(ValueError, match="doesn't match"):
+            service.restore_backup(fake_pg_backup)
+
+
+class TestCleanupBackups:
+    """Test backup cleanup."""
+
+    def test_cleanup_removes_old_backups(self, mock_sqlite_config):
+        """Test that old backups are removed."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        # Create a backup
+        backup_path = service.create_backup()
+
+        # Artificially age the backup (31 days)
+        old_time = time.time() - (31 * 24 * 60 * 60)
+        os.utime(backup_path, (old_time, old_time))
+
+        # Cleanup with 30 day retention
+        removed = service.cleanup_old_backups(retention_days=30)
+
+        assert removed == 1
+        assert not backup_path.exists()
+
+    def test_cleanup_keeps_recent_backups(self, mock_sqlite_config):
+        """Test that recent backups are kept."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        # Create a backup (will be recent)
+        backup_path = service.create_backup()
+
+        # Cleanup with 30 day retention
+        removed = service.cleanup_old_backups(retention_days=30)
+
+        assert removed == 0
+        assert backup_path.exists()
+
+    def test_cleanup_with_mixed_ages(self, mock_sqlite_config):
+        """Test cleanup with mix of old and new backups."""
+        _, backup_dir = mock_sqlite_config
+        service = BackupService(backup_dir=backup_dir)
+
+        # Create old backup
+        old_backup = service.create_backup()
+        old_time = time.time() - (31 * 24 * 60 * 60)
+        os.utime(old_backup, (old_time, old_time))
+
+        # Create new backup (wait for different timestamp)
+        time.sleep(1.1)
+        new_backup = service.create_backup()
+
+        # Cleanup
+        removed = service.cleanup_old_backups(retention_days=30)
+
+        assert removed == 1
+        assert not old_backup.exists()
+        assert new_backup.exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,107 @@
+"""Tests for configuration module."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from passwault.core.config import Config, DatabaseType
+
+
+class TestConfig:
+    """Test suite for Config class."""
+
+    def test_default_database_url_is_sqlite(self, monkeypatch):
+        """Test that default database URL uses SQLite."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
+        url = Config.get_database_url()
+
+        assert url.startswith("sqlite:///")
+        assert "passwault.db" in url
+
+    def test_database_url_from_environment(self, monkeypatch):
+        """Test that DATABASE_URL environment variable is respected."""
+        test_url = "postgresql://user:pass@localhost:5432/testdb"
+        monkeypatch.setenv("DATABASE_URL", test_url)
+
+        url = Config.get_database_url()
+
+        assert url == test_url
+
+    def test_database_type_sqlite(self, monkeypatch):
+        """Test SQLite database type detection."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
+        db_type = Config.get_database_type()
+
+        assert db_type == DatabaseType.SQLITE
+
+    def test_database_type_postgresql(self, monkeypatch):
+        """Test PostgreSQL database type detection."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/test")
+
+        db_type = Config.get_database_type()
+
+        assert db_type == DatabaseType.POSTGRESQL
+
+    def test_database_type_postgres_short_scheme(self, monkeypatch):
+        """Test PostgreSQL detection with 'postgres://' scheme."""
+        monkeypatch.setenv("DATABASE_URL", "postgres://localhost/test")
+
+        db_type = Config.get_database_type()
+
+        assert db_type == DatabaseType.POSTGRESQL
+
+    def test_database_type_unsupported(self, monkeypatch):
+        """Test that unsupported database scheme raises ValueError."""
+        monkeypatch.setenv("DATABASE_URL", "mysql://localhost/test")
+
+        with pytest.raises(ValueError, match="Unsupported database URL scheme"):
+            Config.get_database_type()
+
+    def test_default_backup_dir(self, monkeypatch):
+        """Test default backup directory."""
+        monkeypatch.delenv("PASSWAULT_BACKUP_DIR", raising=False)
+
+        backup_dir = Config.get_backup_dir()
+
+        expected = Path.home() / ".passwault" / "backups"
+        assert backup_dir == expected
+        assert backup_dir.exists()
+
+    def test_backup_dir_from_environment(self, monkeypatch):
+        """Test backup directory from environment variable."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.setenv("PASSWAULT_BACKUP_DIR", tmpdir)
+
+            backup_dir = Config.get_backup_dir()
+
+            assert backup_dir == Path(tmpdir)
+
+    def test_backup_dir_creates_directory(self, monkeypatch):
+        """Test that backup directory is created if it doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_dir = Path(tmpdir) / "new" / "backup" / "dir"
+            monkeypatch.setenv("PASSWAULT_BACKUP_DIR", str(new_dir))
+
+            backup_dir = Config.get_backup_dir()
+
+            assert backup_dir.exists()
+            assert backup_dir == new_dir
+
+    def test_is_postgresql(self, monkeypatch):
+        """Test is_postgresql helper method."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/test")
+        assert Config.is_postgresql() is True
+
+        monkeypatch.delenv("DATABASE_URL")
+        assert Config.is_postgresql() is False
+
+    def test_is_sqlite(self, monkeypatch):
+        """Test is_sqlite helper method."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        assert Config.is_sqlite() is True
+
+        monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/test")
+        assert Config.is_sqlite() is False

--- a/uv.lock
+++ b/uv.lock
@@ -372,6 +372,11 @@ dependencies = [
     { name = "sqlalchemy" },
 ]
 
+[package.optional-dependencies]
+postgres = [
+    { name = "psycopg2-binary" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "black" },
@@ -388,11 +393,13 @@ requires-dist = [
     { name = "cryptography", specifier = ">=45.0.6" },
     { name = "numpy", specifier = ">=2.3.2" },
     { name = "pillow", specifier = ">=11.3.0" },
+    { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.9" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "sqlalchemy", specifier = ">=2.0.44" },
 ]
+provides-extras = ["postgres"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -475,6 +482,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/6c/8767aaa597ba424643dc87348c6f1754dd9f48e80fdc1b9f7ca5c3a7c213/psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c", size = 379620, upload-time = "2025-10-10T11:14:48.041Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/12/93ef0098590cf51d9732b4f139533732565704f45bdc1ffa741b7c95fb54/psycopg2_binary-2.9.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:92e3b669236327083a2e33ccfa0d320dd01b9803b3e14dd986a4fc54aa00f4e1", size = 3756567, upload-time = "2025-10-10T11:13:11.885Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a9/9d55c614a891288f15ca4b5209b09f0f01e3124056924e17b81b9fa054cc/psycopg2_binary-2.9.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0deeb03da539fa3577fcb0b3f2554a97f7e5477c246098dbb18091a4a01c16f", size = 3864755, upload-time = "2025-10-10T11:13:17.727Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1e/98874ce72fd29cbde93209977b196a2edae03f8490d1bd8158e7f1daf3a0/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b52a3f9bb540a3e4ec0f6ba6d31339727b2950c9772850d6545b7eae0b9d7c5", size = 4411646, upload-time = "2025-10-10T11:13:24.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bd/a335ce6645334fb8d758cc358810defca14a1d19ffbc8a10bd38a2328565/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db4fd476874ccfdbb630a54426964959e58da4c61c9feba73e6094d51303d7d8", size = 4468701, upload-time = "2025-10-10T11:13:29.266Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/c8b4f53f34e295e45709b7568bf9b9407a612ea30387d35eb9fa84f269b4/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47f212c1d3be608a12937cc131bd85502954398aaa1320cb4c14421a0ffccf4c", size = 4166293, upload-time = "2025-10-10T11:13:33.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e0/f8cc36eadd1b716ab36bb290618a3292e009867e5c97ce4aba908cb99644/psycopg2_binary-2.9.11-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e35b7abae2b0adab776add56111df1735ccc71406e56203515e228a8dc07089f", size = 3983184, upload-time = "2025-10-30T02:55:32.483Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/2a8fe18a4e61cfb3417da67b6318e12691772c0696d79434184a511906dc/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747", size = 3652650, upload-time = "2025-10-10T11:13:38.181Z" },
+    { url = "https://files.pythonhosted.org/packages/76/36/03801461b31b29fe58d228c24388f999fe814dfc302856e0d17f97d7c54d/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9bd81e64e8de111237737b29d68039b9c813bdf520156af36d26819c9a979e5f", size = 3298663, upload-time = "2025-10-10T11:13:44.878Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -366,9 +366,11 @@ dependencies = [
     { name = "cryptography" },
     { name = "numpy" },
     { name = "pillow" },
+    { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "python-dotenv" },
     { name = "sqlalchemy" },
 ]
 
@@ -393,10 +395,12 @@ requires-dist = [
     { name = "cryptography", specifier = ">=45.0.6" },
     { name = "numpy", specifier = ">=2.3.2" },
     { name = "pillow", specifier = ">=11.3.0" },
+    { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.9" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "sqlalchemy", specifier = ">=2.0.44" },
 ]
 provides-extras = ["postgres"]
@@ -579,6 +583,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add PostgreSQL database support alongside existing SQLite
- Add Docker Compose setup for local PostgreSQL development
- Add SQLite to PostgreSQL migration script
- Add dotenv support for database configuration
- Implement database configuration fallback chain (env var → config file → default SQLite)

## Test plan
- [ ] Run `uv run pytest tests/ -v` to verify all tests pass
- [ ] Test with SQLite (default, no configuration)
- [ ] Test with PostgreSQL via `DATABASE_URL` environment variable
- [ ] Test with PostgreSQL via `~/.config/passwault/.env` config file
- [ ] Verify Docker setup works with `docker-compose up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)