### PR TITLE
Remove session state from Embedder init and add CLI output

### DIFF
--- a/passwault/core/cli.py
+++ b/passwault/core/cli.py
@@ -41,11 +41,16 @@ def handle_imagepass(args, session_manager):
     Returns:
         Result of encode/decode operation
     """
-    embedder = Embedder(args.image_path, session_manager=session_manager)
+    embedder = Embedder(args.image_path)
     if args.option == "encode":
-        return embedder.encode(message=args.password, session_manager=session_manager)
+        result = embedder.encode(message=args.password, session_manager=session_manager)
+        Logger.info(f"Password encoded to: {result}")
     else:
-        return embedder.decode(session_manager=session_manager)
+        message = embedder.decode(session_manager=session_manager)
+        if message:
+            Logger.info(message)
+        else:
+            Logger.error("No hidden password found in the image.")
 
 
 def handle_backup_create(args):

--- a/passwault/imagepass/embedder.py
+++ b/passwault/imagepass/embedder.py
@@ -17,7 +17,6 @@ class Embedder:
         self,
         image_path: Union[Path, str],
         output_dir: Optional[Union[Path, str]] = None,
-        session_manager: Optional[SessionManager] = None,
     ) -> None:
         self.image_path = (
             image_path if isinstance(image_path, Path) else Path(image_path)
@@ -28,13 +27,6 @@ class Embedder:
             else Path(output_dir)
         )
         self.image_handler = ImageHandler(self.image_path, self.output_dir)
-        self.session_manager = session_manager
-        self.session = None
-        self.user_id = None
-
-        if session_manager:
-            self.session = session_manager.get_session()
-            self.user_id = self.session["user_id"] if self.session else None
 
     def _create_bands_bitmask(self) -> int:
         """Bitmask for R/G/B/A/L channels
@@ -223,7 +215,6 @@ class Embedder:
             band_values = self.image_handler.get_band_values(band)
 
             header_bytes = self._get_header_bytes(band_values)
-
             if header_bytes:
                 header = self._unpack_header(header_bytes)
                 message, message_crc = self._retrieve_message_lsb(

--- a/tests/imagepass/test_embedder.py
+++ b/tests/imagepass/test_embedder.py
@@ -5,7 +5,7 @@ MESSAGE = "This is my message to the world, but it should be hidden"
 
 
 def test_create_bands_byte_rgb(tmp_image_rgb, session_manager):
-    embedder = Embedder(tmp_image_rgb, session_manager=session_manager)
+    embedder = Embedder(tmp_image_rgb)
     bands_bitmask = embedder._create_bands_bitmask()
 
     assert (bands_bitmask >> 0) & 1 == 1
@@ -16,7 +16,7 @@ def test_create_bands_byte_rgb(tmp_image_rgb, session_manager):
 
 
 def test_create_bands_byte_rgba(tmp_image_rgba, session_manager):
-    embedder = Embedder(tmp_image_rgba, session_manager=session_manager)
+    embedder = Embedder(tmp_image_rgba)
     bands_bitmask = embedder._create_bands_bitmask()
 
     assert (bands_bitmask >> 0) & 1 == 1
@@ -27,7 +27,7 @@ def test_create_bands_byte_rgba(tmp_image_rgba, session_manager):
 
 
 def test_create_bands_byte_bw(tmp_image_bw, session_manager):
-    embedder = Embedder(tmp_image_bw, session_manager=session_manager)
+    embedder = Embedder(tmp_image_bw)
     bands_bitmask = embedder._create_bands_bitmask()
 
     assert (bands_bitmask >> 0) & 1 == 0
@@ -40,14 +40,14 @@ def test_create_bands_byte_bw(tmp_image_bw, session_manager):
 def test_header_size(tmp_image_rgb, session_manager):
     # header must be a fixed 24 bytes
 
-    embedder = Embedder(tmp_image_rgb, session_manager=session_manager)
+    embedder = Embedder(tmp_image_rgb)
     key = key_generator()
     header = embedder._create_header(key, len(MESSAGE))
     assert len(header) == 24
 
 
 def test_unpack_header(tmp_image_rgb, session_manager):
-    embedder = Embedder(tmp_image_rgb, session_manager=session_manager)
+    embedder = Embedder(tmp_image_rgb)
 
     key = key_generator()
     header_bytes = embedder._create_header(key, len(MESSAGE))
@@ -60,7 +60,7 @@ def test_unpack_header(tmp_image_rgb, session_manager):
 
 
 def test_insert_header_lsb(tmp_image_rgb, session_manager):
-    embedder = Embedder(tmp_image_rgb, session_manager=session_manager)
+    embedder = Embedder(tmp_image_rgb)
     test_bytes = [255] * 60_000
     key = key_generator()
 

--- a/tests/imagepass/test_functional.py
+++ b/tests/imagepass/test_functional.py
@@ -24,14 +24,14 @@ def test_encode_decode(tmp_path, session_manager):
     """
 
     # Initialize the encoder
-    encoder = Embedder(test_image, output_dir, session_manager=session_manager)
+    encoder = Embedder(test_image, output_dir)
 
     encoder.encode(message, session_manager=session_manager)
     result_image = output_dir / "sample_image.png"
     assert result_image.exists(), "Encoded image was not created."
 
     # Initialize the decoder
-    decoder = Embedder(result_image, session_manager=session_manager)
+    decoder = Embedder(result_image)
     decoded_message = decoder.decode(session_manager=session_manager)
     assert decoded_message is not None, "Decoded message is None."
     assert message == decoded_message, "Decoded message does not match the original."
@@ -43,13 +43,13 @@ def test_encode_decode_grayscale(tmp_path, tmp_image_bw, session_manager):
 
     message = "secret password 123!"
 
-    encoder = Embedder(tmp_image_bw, output_dir, session_manager=session_manager)
+    encoder = Embedder(tmp_image_bw, output_dir)
     encoder.encode(message, session_manager=session_manager)
 
     result_image = output_dir / "test_bw.png"
     assert result_image.exists(), "Encoded grayscale image was not created."
 
-    decoder = Embedder(result_image, session_manager=session_manager)
+    decoder = Embedder(result_image)
     decoded_message = decoder.decode(session_manager=session_manager)
     assert decoded_message is not None, "Decoded message is None."
     assert message == decoded_message, "Decoded message does not match the original."
@@ -60,7 +60,7 @@ def test_encode_message_larger_than_capacity(tmp_image_rgb, session_manager):
     large_message = "A" * 10**7  # 10 million characters
 
     # Initialize the encoder
-    encoder = Embedder(tmp_image_rgb, session_manager=session_manager)
+    encoder = Embedder(tmp_image_rgb)
 
     # Expect a ValueError to be raised due to insufficient capacity
     try:


### PR DESCRIPTION
Remove unused session_manager, session, and user_id from Embedder __init__ since the @require_auth decorator gets session_manager from the encode/decode method arguments directly. Also add Logger output for imagepass encode/decode results in the CLI handler.